### PR TITLE
Correção de alguns exemplos

### DIFF
--- a/src/glut-super-basic/main.cpp
+++ b/src/glut-super-basic/main.cpp
@@ -6,8 +6,8 @@
  * License: MIT
  */
 
-#include <gl/glut.h>
-#include <gl/gl.h>
+#include <GL/glut.h>
+#include <GL/gl.h>
 #include <iostream>
 
 // Constants to define the width/height of the window

--- a/src/light/main.cpp
+++ b/src/light/main.cpp
@@ -2,7 +2,7 @@
 *   Programa para ilustrar:
 *   - Uso da Material
 *   - Gouraud Shading
-*   - Projecao ortográfica
+*   - Projecao ortogrï¿½fica
 
 *   Autor: Cesar Tadeu Pozzer
 *   UFSM - 15/06/2007
@@ -61,7 +61,6 @@ void init(void)
 
 void display(void)
 {
-     Sleep(3);
    glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
    glLoadIdentity();
@@ -137,7 +136,7 @@ int main(int argc, char** argv)
    glutInitDisplayMode (GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
    glutInitWindowSize (600, 600);
    glutInitWindowPosition (100, 100);
-   glutCreateWindow("Iluminação. Pressione W ou outra tecla");
+   glutCreateWindow("Iluminaï¿½ï¿½o. Pressione W ou outra tecla");
    init ();
    glutDisplayFunc(display);
    glutKeyboardFunc(keyboard);

--- a/src/moving-plane/Point.h
+++ b/src/moving-plane/Point.h
@@ -3,6 +3,7 @@
 
 #include <GL/freeglut.h>
 #include <algorithm>
+#include <cmath>
 
 // 3D point/vector class
 class Point {

--- a/src/moving-plane/main.cpp
+++ b/src/moving-plane/main.cpp
@@ -4,8 +4,6 @@
 #include "Point.h"
 using namespace std;
 
-#define M_PI 3.14159
-
 // global variables
 static struct {
 	// current parameters for controlling glulookat

--- a/src/rotation/main.cpp
+++ b/src/rotation/main.cpp
@@ -26,7 +26,6 @@ float angGraus = 0;
 ////////////////////////////////////////////////////////////////////////////////////////
 void display(void)
 {
-   Sleep(10);
 
    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 

--- a/src/simple-terrain/main.cpp
+++ b/src/simple-terrain/main.cpp
@@ -27,8 +27,6 @@ void render(void)
 {
    color(1,0,0);
 
-   Sleep(10);
-
    s->transforma();
    s->render();
 }

--- a/src/transformation-simple/main.cpp
+++ b/src/transformation-simple/main.cpp
@@ -2,8 +2,8 @@
  * Simple demonstration of transformations.
  */
 
-#include <gl/glut.h>
-#include <gl/gl.h>
+#include <GL/glut.h>
+#include <GL/gl.h>
 
 void renderCoordinateAxis()
 {


### PR DESCRIPTION
Alguns exemplos não estavam funcionando no Linux. Uns por causa da importação do Open GL e outros por causa do `Sleep`.
Arrumei as importações e removi os `Sleep`